### PR TITLE
clean InputTextBox.Text when setted null item

### DIFF
--- a/FuzzySearchComboBox/FuzzySearchComboBox/FuzzySearchCombobox.xaml.cs
+++ b/FuzzySearchComboBox/FuzzySearchComboBox/FuzzySearchCombobox.xaml.cs
@@ -913,8 +913,8 @@ namespace Controls.FuzzySearchComboBox
 
             SelectedKey = null;
             SelectedValue = null;
-            if (_textChangedCodebehind)
-                InputTextBox.Text = string.Empty;
+            //if (_textChangedCodebehind) это поле всегда false и ни на что не влияет, а InputTextBox надо очищать, если item == null
+            InputTextBox.Text = string.Empty;
 
             ChildItems = GetChilds(ParentItemsSource);
             ParentItems = null;


### PR DESCRIPTION
Добавила очистку текстового поля, когда выбирается нулевой элемент. Например, при очистке перед присвоением новых значений. Если этого не делать, то при удалении выбранного элемента в коде будет продолжать отображаться старое значение, хотя это не так.
