### PR TITLE
Address information: do autocomplete only for parent combobox and don…

### DIFF
--- a/FuzzySearchComboBox/FuzzySearchComboBox/FuzzySearchCombobox.xaml.cs
+++ b/FuzzySearchComboBox/FuzzySearchComboBox/FuzzySearchCombobox.xaml.cs
@@ -339,22 +339,6 @@ namespace Controls.FuzzySearchComboBox
                     parentCombobox.SelectedItem = item;
                 }
             }
-
-            //child combobox
-            var bindingChild = GetBindingExpression(ChildItemsSourceProperty);
-            var childCombobox = bindingChild?.DataItem as FuzzySearchCombobox;
-
-            if (IsControlRequiresAutocomplete(childCombobox))
-            {
-                var internalItemsSource = childCombobox.InternalItemsSource;
-
-                if (internalItemsSource != null && internalItemsSource.Count(x => !x.Value.IsDeleted) == 1)
-                {
-                    //Do autocomplete only using not deleted items
-                    var item = internalItemsSource.FirstOrDefault(x => !x.Value.IsDeleted);
-                    childCombobox.SelectedItem = item;
-                }
-            }
         }
 
         private static bool IsControlRequiresAutocomplete(FuzzySearchCombobox combobox)


### PR DESCRIPTION
Address information: do autocomplete only for parent combobox and don't  for child. 
It is need for exclude side effects: it is not possible to separate the cases when the selected key of the combo box is taken from the database, and when selected by the user. This resulted in the parasitic autocomplete of the child box.